### PR TITLE
Change Storage Account Type to "Standard_LRS"

### DIFF
--- a/Enterprise/base-configuration-dev-test-environment.md
+++ b/Enterprise/base-configuration-dev-test-environment.md
@@ -145,8 +145,8 @@ $cred=Get-Credential -Message "Type the name and password of the local administr
 $vm=Set-AzureRMVMOperatingSystem -VM $vm -Windows -ComputerName DC1 -Credential $cred -ProvisionVMAgent -EnableAutoUpdate
 $vm=Set-AzureRMVMSourceImage -VM $vm -PublisherName MicrosoftWindowsServer -Offer WindowsServer -Skus 2016-Datacenter -Version "latest"
 $vm=Add-AzureRMVMNetworkInterface -VM $vm -Id $nic.Id
-$vm=Set-AzureRmVMOSDisk -VM $vm -Name "DC1-OS" -DiskSizeInGB 128 -CreateOption FromImage -StorageAccountType "StandardLRS"
-$diskConfig=New-AzureRmDiskConfig -AccountType "StandardLRS" -Location $locName -CreateOption Empty -DiskSizeGB 20
+$vm=Set-AzureRmVMOSDisk -VM $vm -Name "DC1-OS" -DiskSizeInGB 128 -CreateOption FromImage -StorageAccountType "Standard_LRS"
+$diskConfig=New-AzureRmDiskConfig -AccountType "Standard_LRS" -Location $locName -CreateOption Empty -DiskSizeGB 20
 $dataDisk1=New-AzureRmDisk -DiskName "DC1-DataDisk1" -Disk $diskConfig -ResourceGroupName $rgName
 $vm=Add-AzureRmVMDataDisk -VM $vm -Name "DC1-DataDisk1" -CreateOption Attach -ManagedDiskId $dataDisk1.Id -Lun 1
 New-AzureRMVM -ResourceGroupName $rgName -Location $locName -VM $vm


### PR DESCRIPTION
At Lines 148 and 149, the values -StorageAccountType and -AccountType need to be changed from "StorageLRS" to "Storage_LRS". Otherwise running Line 152 will throw the following error message:

PS C:\Windows\system32> New-AzureRMVM -ResourceGroupName $rgName -Location $locName -VM $vm
WARNUNG: New-AzureRmVM: A property of the output of this cmdlet will change in an upcoming
breaking change release. The StorageAccountType property for a DataDisk will return
Standard_LRS and Premium_LRS
New-AzureRMVM : Error converting value "StandardLRS" to type 'System.Nullable`1[Microsoft.Azure.XStoreClientHelper.StorageAccountServiceClient.StorageAccountType]'. Path
'properties.storageProfile.osDisk.managedDisk.storageAccountType', line 19, position 45.
ErrorCode: BadRequest
ErrorMessage: Error converting value "StandardLRS" to type 'System.Nullable`1[Microsoft.Azure.XStoreClientHelper.StorageAccountServiceClient.StorageAccountType]'. Path
'properties.storageProfile.osDisk.managedDisk.storageAccountType', line 19, position 45.
StatusCode: 400
ReasonPhrase: Bad Request
OperationID : 241bd5bf-b06e-47f5-a06a-2e9976043030
In Zeile:1 Zeichen:1
+ New-AzureRMVM -ResourceGroupName $rgName -Location $locName -VM $vm
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : CloseError: (:) [New-AzureRmVM], ComputeCloudException
    + FullyQualifiedErrorId : Microsoft.Azure.Commands.Compute.NewAzureVMCommand