### PR TITLE
Fix Typo in the New-PSSession Command for Delgate Partner Access in Exchange Online

### DIFF
--- a/Enterprise/powershell/connect-to-exchange-online-tenants-with-remote-windows-powershell-for-delegated.md
+++ b/Enterprise/powershell/connect-to-exchange-online-tenants-with-remote-windows-powershell-for-delegated.md
@@ -64,7 +64,7 @@ DAP partners are Syndication and Cloud Solution Providers (CSP) partners. They a
 2. Run the following command, replacing  _<customer tenant domain name>_ with the name of the tenant domain that you want to connect to.
     
   ```
-  $Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.outlook.com/powershell-liveid?DelegatedOrg=<customer tenant domain name>-Credential $UserCredential -Authentication Basic -AllowRedirection
+  $Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.outlook.com/powershell-liveid?DelegatedOrg=<customer tenant domain name> -Credential $UserCredential -Authentication Basic -AllowRedirection
   ```
 
     The key step in this command is specifying which customer to access for the reporting information. You do this in the  _ConnectionURI_ parameter, where you provide the FQDN of the initial domain name as the value to the _DelegatedOrg_ parameter. This tells remote Windows PowerShell for Exchange Online PowerShell remote Windows PowerShell the endpoint to connect to. remote Windows PowerShell must connect to Office 365 reporting in the context of a specific customer each time a report is run. After this customer is specified, all of the following commands are run in the context of that customer. This lets the partner to access all the available reports for this customer.


### PR DESCRIPTION
There was no space between the PoSh session URL and the next argument -Credential
I have added this space as it has irked me one to many times!