### PR TITLE
Syntax fix and change to some codeblocks

### DIFF
--- a/Enterprise/configure-exchange-server-for-hybrid-modern-authentication.md
+++ b/Enterprise/configure-exchange-server-for-hybrid-modern-authentication.md
@@ -3,7 +3,7 @@ title: "How to configure Exchange Server on-premises to use Hybrid Modern Authen
 ms.author: tracyp
 author: MSFTTracyP
 manager: laurawi
-ms.date: 3/23/2018
+ms.date: 09/28/2018
 ms.audience: ITPro
 ms.topic: article
 ms.service: o365-administration

--- a/Enterprise/configure-exchange-server-for-hybrid-modern-authentication.md
+++ b/Enterprise/configure-exchange-server-for-hybrid-modern-authentication.md
@@ -58,13 +58,12 @@ Run the commands that assign your on-premises web service URLs as Azure AD SPNs.
   
 First, gather all the URLs that you need to add in AAD. Run these commands on-premises:
   
-- Get-MapiVirtualDirectory | FL server,\*url\*
-    
-- Get-WebServicesVirtualDirectory | FL server,\*url\*
-    
-- **Get-ActiveSyncVirtualDirectory | FL server,\*url\***
-    
-- Get-OABVirtualDirectory | FL server,\*url\*
+```powershell
+Get-MapiVirtualDirectory | FL server,*url*
+Get-WebServicesVirtualDirectory | FL server,*url*
+Get-ActiveSyncVirtualDirectory | FL server,*url*
+Get-OABVirtualDirectory | FL server,*url*
+```
     
 Ensure the URLs clients may connect to are listed as HTTPS service principal names in AAD.
   
@@ -72,17 +71,19 @@ Ensure the URLs clients may connect to are listed as HTTPS service principal nam
     
 2. For your Exchange related URLs, type the following command:
     
-- Get-MsolServicePrincipal -AppPrincipalId 00000002-0000-0ff1-ce00-000000000000 | select -ExpandProperty ServicePrincipalNames
-    
-Take note of (and screenshot for later comparison) the output of this command, which should include an https:// *autodiscover. *yourdomain*  .com *  and https://  *mail.yourdomain.com*  URL, but mostly consist of SPNs that begin with 00000002-0000-0ff1-ce00-000000000000/. If there are https:// URLs from your on-premises that are missing we will need to add those specific records to this list. 
+```powershell
+Get-MsolServicePrincipal -AppPrincipalId 00000002-0000-0ff1-ce00-000000000000 | select -ExpandProperty ServicePrincipalNames
+```
+
+Take note of (and screenshot for later comparison) the output of this command, which should include an https://  *autodiscover.yourdomain.com*  and https://  *mail.yourdomain.com*  URL, but mostly consist of SPNs that begin with 00000002-0000-0ff1-ce00-000000000000/. If there are https:// URLs from your on-premises that are missing we will need to add those specific records to this list. 
   
 3. If you don't see your internal and external MAPI/HTTP, EWS, ActiveSync, OAB and Autodiscover records in this list, you must add them using the command below (the example URLs are '`mail.corp.contoso.com`' and '`owa.contoso.com`', but you'd **replace the example URLs with your own** ): <br/>
-```
-- $x= Get-MsolServicePrincipal -AppPrincipalId 00000002-0000-0ff1-ce00-000000000000   
-- $x.ServicePrincipalnames.Add("https://mail.corp.contoso.com/")
-- $x.ServicePrincipalnames.Add("https://owa.contoso.com/")
-- $x.ServicePrincipalnames.Add("https://eas.contoso.com/")
-- Set-MSOLServicePrincipal -AppPrincipalId 00000002-0000-0ff1-ce00-000000000000 -ServicePrincipalNames $x.ServicePrincipalNames
+```powershell
+$x= Get-MsolServicePrincipal -AppPrincipalId 00000002-0000-0ff1-ce00-000000000000   
+$x.ServicePrincipalnames.Add("https://mail.corp.contoso.com/")
+$x.ServicePrincipalnames.Add("https://owa.contoso.com/")
+$x.ServicePrincipalnames.Add("https://eas.contoso.com/")
+Set-MSOLServicePrincipal -AppPrincipalId 00000002-0000-0ff1-ce00-000000000000 -ServicePrincipalNames $x.ServicePrincipalNames
 ```
  
 4. Verify your new records were added by running the Get-MsolServicePrincipal command from step 2 again, and looking through the output. Compare the list / screenshot from before to the new list of SPNs (you may also screenshot the new list for your records). If you were successful, you will see the two new URLs in the list. Going by our example, the list of SPNs will now include the specific URLs  `https://mail.corp.contoso.com`  and  `https://owa.contoso.com`. 
@@ -91,28 +92,27 @@ Take note of (and screenshot for later comparison) the output of this command, w
 
 Now verify OAuth is properly enabled in Exchange on all of the Virtual Directories Outlook might use by running the following commands:
 
-```
-Get-MapiVirtualDirectory | FL server,\*url\*,\*auth\* 
-Get-WebServicesVirtualDirectory | FL server,\*url\*,\*oauth\*
-Get-OABVirtualDirectory | FL server,\*url\*,\*oauth\*
-Get-AutoDiscoverVirtualDirectory | FL server,\*oauth\*
+```powershell
+Get-MapiVirtualDirectory | FL server,*url*,*auth* 
+Get-WebServicesVirtualDirectory | FL server,*url*,*oauth*
+Get-OABVirtualDirectory | FL server,*url*,*oauth*
+Get-AutoDiscoverVirtualDirectory | FL server,*oauth*
 ```
 
 Check the output to make sure **OAuth** is enabled on each of these VDirs, it will look something like this (and the key thing to look at is 'OAuth'); 
-  
- **[PS] C:\Windows\system32\>Get-MapiVirtualDirectory | fl server,\*url\*,\*auth\***
-  
- **Server : EX1**
-  
- **InternalUrl : `https://mail.contoso.com/mapi`**
-  
- **ExternalUrl : `https://mail.contoso.com/mapi`**
-  
- **IISAuthenticationMethods : {Ntlm, OAuth, Negotiate}**
-  
- **InternalAuthenticationMethods : {Ntlm, OAuth, Negotiate}**
-  
- **ExternalAuthenticationMethods : {Ntlm, OAuth, Negotiate}**
+
+```powershell
+Get-MapiVirtualDirectory | fl server,*url*,*auth*
+```
+
+```
+Server                        : EX1
+InternalUrl                   : https://mail.contoso.com/mapi
+ExternalUrl                   : https://mail.contoso.com/mapi
+IISAuthenticationMethods      : {Ntlm, OAuth, Negotiate}
+InternalAuthenticationMethods : {Ntlm, OAuth, Negotiate}
+ExternalAuthenticationMethods : {Ntlm, OAuth, Negotiate}
+```
   
 If OAuth is missing from any server and any of the four virtual directories then you need to add it using the relevant commands before proceeding.
   
@@ -120,8 +120,10 @@ If OAuth is missing from any server and any of the four virtual directories then
 
 Return to the on-premises Exchange Management Shell for this last command. Now you can validate that your on-premises has an entry for the evoSTS authentication provider:
   
-`Get-AuthServer | where {$_.Name -eq "EvoSts"}`
-    
+```powershell
+Get-AuthServer | where {$_.Name -eq "EvoSts"}
+```
+
 Your output should show an AuthServer of the Name EvoSts and the 'Enabled' state should be True. If you don't see this, you should download and run the most recent version of the Hybrid Configuration Wizard.
   
  **Important** If you're running Exchange 2010 in your environment, the EvoSTS authentication provider won't be created. 
@@ -130,7 +132,7 @@ Your output should show an AuthServer of the Name EvoSts and the 'Enabled' state
 
 Run the following command in the Exchange Management Shell, on-premises:
 
-```
+```powershell
 Set-AuthServer -Identity EvoSTS -IsDefaultAuthorizationEndpoint $true  
 Set-OrganizationConfig -OAuth2ClientProfileEnabled $true
 ```


### PR DESCRIPTION
There was some errant formatting around "autodiscover.yourdomain.com" causing the italics to not apply, and showing an asterisk that shouldn't be there.

Also noticed while following this doc that some of the code blocks weren't copy/paste-able (there were remands of bullet lists in some, and now-unneeded escape characters.)

While fixing those I've also gone through and standardized the code on the page, making all of the examples copy/past-able and separated output from the command itself.