### PR TITLE
Added section for finding linked AD user from MSOL user

### DIFF
--- a/Enterprise/powershell/view-user-accounts-with-office-365-powershell.md
+++ b/Enterprise/powershell/view-user-accounts-with-office-365-powershell.md
@@ -175,6 +175,10 @@ Brian Johnson
 Scott Wallace            Operations
 ```
 
+If you are using directory synchronization to create and manage your Office 365 users, you can display which local account an Office 365 user has been projected from. The following assumes that Azure AD Connect has been configured to use the default source anchor of ObjectGUID (for more on configuring a source anchor, see [Azure AD Connect: Design concepts](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/plan-connect-design-concepts)) and assumes that the Active Directory module for powershell has been installed (see [RSAT tools](https://www.microsoft.com/en-gb/download/details.aspx?id=45520)):
+```
+(Get-ADUser [guid][system.convert]::frombase64string((Get-MsolUser -UserPrincipalName <UPN of user account>).ImmutableID)).Guid
+```
 ## Use the Azure Active Directory V2 PowerShell module to display user accounts
 
 To display properties for user accounts with the Azure Active Directory V2 PowerShell module, you use the [Get-AzureADUser](https://docs.microsoft.com/powershell/module/azuread/get-azureaduser?view=azureadps-2.0) cmdlet. But first, you must connect to your subscription. For the instructions, see[Connect with the Azure Active Directory V2 PowerShell module](https://go.microsoft.com/fwlink/?linkid=842218).

--- a/Enterprise/powershell/view-user-accounts-with-office-365-powershell.md
+++ b/Enterprise/powershell/view-user-accounts-with-office-365-powershell.md
@@ -3,7 +3,7 @@ title: "View user accounts with Office 365 PowerShell"
 ms.author: josephd
 author: JoeDavies-MSFT
 manager: laurawi
-ms.date: 12/15/2017
+ms.date: 10/08/2018
 ms.audience: Admin
 ms.topic: article
 ms.service: o365-administration


### PR DESCRIPTION
Maybe too complex for this page? Useful powershell to find a linked on-premise principle from an MSOL user using ImmutableID and matching it to the on-premise source anchor.