### PR TITLE
update modern-auth-for-office-2013-and-2016.md

### DIFF
--- a/Enterprise/modern-auth-for-office-2013-and-2016.md
+++ b/Enterprise/modern-auth-for-office-2013-and-2016.md
@@ -28,7 +28,7 @@ description: "Learn how Office 365 modern authentication works differently for O
 Read this article to learn how Office 2013 and Office 2016 client apps use modern authentication features based on the authentication configuration on the Office 365 tenant for Exchange Online, SharePoint Online, and Skype for Business Online.
 
 > [!NOTE]
-> Legacy client apps, such as Office 2010 or Office for Mac 2011, do not support modern authentication and could be used with basic authentication only.
+> Legacy client apps, such as Office 2010 and Office for Mac 2011, do not support modern authentication and can only be used with basic authentication.
 
 ## Availability of modern authentication for Office 365 services
 

--- a/Enterprise/modern-auth-for-office-2013-and-2016.md
+++ b/Enterprise/modern-auth-for-office-2013-and-2016.md
@@ -26,7 +26,10 @@ description: "Learn how Office 365 modern authentication works differently for O
 # How modern authentication works for Office 2013 and Office 2016 client apps
 
 Read this article to learn how Office 2013 and Office 2016 client apps use modern authentication features based on the authentication configuration on the Office 365 tenant for Exchange Online, SharePoint Online, and Skype for Business Online.
-  
+
+> [!NOTE]
+> Legacy client apps, such as Office 2010 or Office for Mac 2011, do not support modern authentication and could be used with basic authentication only.
+
 ## Availability of modern authentication for Office 365 services
 
 For the Office 365 services, the default state of modern authentication is:


### PR DESCRIPTION
issue #364 ,
source [Updated Office 365 modern authentication](https://www.microsoft.com/microsoft-365/blog/2015/11/19/updated-office-365-modern-authentication-public-preview)

As the article's title is "How modern authentication works for Office 2013 and Office 2016 client apps", I didn't add Office 2010 in the table, I just added the "Note" to clarify that Office 2010 is not supported