### PR TITLE
Vanity domain

### DIFF
--- a/Enterprise/use-office-365-cdn-with-spo.md
+++ b/Enterprise/use-office-365-cdn-with-spo.md
@@ -24,8 +24,7 @@ You can use the built-in Office 365 Content Delivery Network (CDN) to host stati
 > [!NOTE]
 > Restrictions for use of the Office 365 CDN:
 > + The Office 365 CDN is only available to tenants in the **Production** (worldwide) cloud. Tenants in the US Government, China and Germany clouds do not currently support the Office 365 CDN.
-> + The Office 365 CDN does not currently support tenants configured with custom or "vanity" domains. If you have added a domain to your tenant using the instructions in the topic [Add a domain to Office 365](https://docs.microsoft.com/en-us/office365/admin/setup/add-domain?view=o365-worldwide), the Office 365 CDN will return errors when you try to access content from the CDN.
-> + If vanity domain is set up for any of the Office 365 components, the Office 365 CDN services will not work.
+> + The Office 365 CDN does not currently support tenants configured with custom or "vanity" domains. If you have added a domain to any of your Office 365 component in your tenant using the instructions in the topic [Add a domain to Office 365](https://docs.microsoft.com/en-us/office365/admin/setup/add-domain?view=o365-worldwide), the Office 365 CDN will return errors when you try to access content from the CDN.
 
 The Office 365 CDN is composed of multiple CDNs that allow you to host static assets in multiple locations, or _origins_, and serve them from global high-speed networks. Depending on the kind of content you want to host in the Office 365 CDN, you can add **public** origins, **private** origins or both. See [Choose whether each origin should be public or private](use-office-365-cdn-with-spo.md#CDNOriginChoosePublicPrivate) for more information on the difference between public and private origins.
 

--- a/Enterprise/use-office-365-cdn-with-spo.md
+++ b/Enterprise/use-office-365-cdn-with-spo.md
@@ -25,6 +25,7 @@ You can use the built-in Office 365 Content Delivery Network (CDN) to host stati
 > Restrictions for use of the Office 365 CDN:
 > + The Office 365 CDN is only available to tenants in the **Production** (worldwide) cloud. Tenants in the US Government, China and Germany clouds do not currently support the Office 365 CDN.
 > + The Office 365 CDN does not currently support tenants configured with custom or "vanity" domains. If you have added a domain to your tenant using the instructions in the topic [Add a domain to Office 365](https://docs.microsoft.com/en-us/office365/admin/setup/add-domain?view=o365-worldwide), the Office 365 CDN will return errors when you try to access content from the CDN.
+> + If vanity domain is setup for any of the Office 365 component, CDN services will not work.
 
 The Office 365 CDN is composed of multiple CDNs that allow you to host static assets in multiple locations, or _origins_, and serve them from global high-speed networks. Depending on the kind of content you want to host in the Office 365 CDN, you can add **public** origins, **private** origins or both. See [Choose whether each origin should be public or private](use-office-365-cdn-with-spo.md#CDNOriginChoosePublicPrivate) for more information on the difference between public and private origins.
 

--- a/Enterprise/use-office-365-cdn-with-spo.md
+++ b/Enterprise/use-office-365-cdn-with-spo.md
@@ -25,7 +25,7 @@ You can use the built-in Office 365 Content Delivery Network (CDN) to host stati
 > Restrictions for use of the Office 365 CDN:
 > + The Office 365 CDN is only available to tenants in the **Production** (worldwide) cloud. Tenants in the US Government, China and Germany clouds do not currently support the Office 365 CDN.
 > + The Office 365 CDN does not currently support tenants configured with custom or "vanity" domains. If you have added a domain to your tenant using the instructions in the topic [Add a domain to Office 365](https://docs.microsoft.com/en-us/office365/admin/setup/add-domain?view=o365-worldwide), the Office 365 CDN will return errors when you try to access content from the CDN.
-> + If vanity domain is setup for any of the Office 365 component, CDN services will not work.
+> + If vanity domain is set up for any of the Office 365 components, the Office 365 CDN services will not work.
 
 The Office 365 CDN is composed of multiple CDNs that allow you to host static assets in multiple locations, or _origins_, and serve them from global high-speed networks. Depending on the kind of content you want to host in the Office 365 CDN, you can add **public** origins, **private** origins or both. See [Choose whether each origin should be public or private](use-office-365-cdn-with-spo.md#CDNOriginChoosePublicPrivate) for more information on the difference between public and private origins.
 

--- a/Enterprise/use-office-365-cdn-with-spo.md
+++ b/Enterprise/use-office-365-cdn-with-spo.md
@@ -24,7 +24,7 @@ You can use the built-in Office 365 Content Delivery Network (CDN) to host stati
 > [!NOTE]
 > Restrictions for use of the Office 365 CDN:
 > + The Office 365 CDN is only available to tenants in the **Production** (worldwide) cloud. Tenants in the US Government, China and Germany clouds do not currently support the Office 365 CDN.
-> + The Office 365 CDN does not currently support tenants configured with custom or "vanity" domains. If you have added a domain to any of your Office 365 component in your tenant using the instructions in the topic [Add a domain to Office 365](https://docs.microsoft.com/en-us/office365/admin/setup/add-domain?view=o365-worldwide), the Office 365 CDN will return errors when you try to access content from the CDN.
+> + The Office 365 CDN does not currently support tenants configured with custom or "vanity" domains. If you have added a domain to any component in your Office 365 tenant using the instructions in the topic [Add a domain to Office 365](https://docs.microsoft.com/en-us/office365/admin/setup/add-domain?view=o365-worldwide), the Office 365 CDN will return errors when you try to access content from the CDN.
 
 The Office 365 CDN is composed of multiple CDNs that allow you to host static assets in multiple locations, or _origins_, and serve them from global high-speed networks. Depending on the kind of content you want to host in the Office 365 CDN, you can add **public** origins, **private** origins or both. See [Choose whether each origin should be public or private](use-office-365-cdn-with-spo.md#CDNOriginChoosePublicPrivate) for more information on the difference between public and private origins.
 


### PR DESCRIPTION
If the vanity domain is set up at any part of Office365, CDN services will not work.

Problem: https://github.com/MicrosoftDocs/OfficeDocs-Enterprise/issues/479