### PR TITLE
Update configure-search-for-multi-geo.md

### DIFF
--- a/Enterprise/configure-search-for-multi-geo.md
+++ b/Enterprise/configure-search-for-multi-geo.md
@@ -172,10 +172,7 @@ For each geo location, you must ensure that all users in the organization have b
 
 ### Query parameters
 
-EnableMultiGeoSearch - This is a Boolean value that specifies whether the query shall be fanned out to the indexes of other geo locations of the multi-geo tenant. Set it to **true** to fan out the query; **false** to not fan out the query. The default value is **false**. If you don't include this parameter, the query is not fanned out to other geo locations. If you use the parameter in an environment that isn't multi-geo, the parameter is ignored.
-
-> [!NOTE]
-> EnableMultiGeoSearch parameter will default to **true** when the REST API is called against a site using the Enterprise Search Center template, unless you include this parameter and set it to false.
+EnableMultiGeoSearch - This is a Boolean value that specifies whether the query shall be fanned out to the indexes of other geo locations of the multi-geo tenant. Set it to **true** to fan out the query; **false** to not fan out the query. If you don't include this parameter, the default value is **false**, except when making a REST API call against a site which uses the Enterprise Search Center template, in this case the default value is **true**. If you use the parameter in an environment that isn't multi-geo, the parameter is ignored.
 
 ClientType - This is a string. Enter a unique client name for each search application. If you don't include this parameter, the query is not fanned out to other geo locations.
 

--- a/Enterprise/configure-search-for-multi-geo.md
+++ b/Enterprise/configure-search-for-multi-geo.md
@@ -174,6 +174,9 @@ For each geo location, you must ensure that all users in the organization have b
 
 EnableMultiGeoSearch - This is a Boolean value that specifies whether the query shall be fanned out to the indexes of other geo locations of the multi-geo tenant. Set it to **true** to fan out the query; **false** to not fan out the query. The default value is **false**. If you don't include this parameter, the query is not fanned out to other geo locations. If you use the parameter in an environment that isn't multi-geo, the parameter is ignored.
 
+> [!NOTE]
+> EnableMultiGeoSearch parameter will default to **true** when the REST API is called against a site using the Enterprise Search Center template, unless you include this parameter and set it to false.
+
 ClientType - This is a string. Enter a unique client name for each search application. If you don't include this parameter, the query is not fanned out to other geo locations.
 
 MultiGeoSearchConfiguration - This is an optional list of which geo locations in the multi-geo tenant to fan the query out to when **EnableMultiGeoSearch** is **true**. If you don't include this parameter, or leave it blank, the query is fanned out to all geo locations. For each geo location, enter the following items, in JSON format:


### PR DESCRIPTION
We ran across an instance with a customer who is using Result Sources to call SPO and it is pointing to their Enterprise Search Center site template. After testing and review of the source code (against the method IsMultiGeoAutoForwardingEnabled) it looks to be by design to change the value for "EnableMultiGeoSearch" to true when using an Enterprise search center template.

The Change added above is a note on this parameter to clarify that calls against the enterprise search center template will change the default behavior.