### PR TITLE
Fixed spelling error

### DIFF
--- a/Enterprise/subscriptions-licenses-accounts-and-tenants-for-microsoft-cloud-offerings.md
+++ b/Enterprise/subscriptions-licenses-accounts-and-tenants-for-microsoft-cloud-offerings.md
@@ -68,7 +68,7 @@ For Azure PaaS-based cloud services, software licenses are built into the servic
   
 For Azure IaaS-based virtual machines, additional licenses to use the software or application installed on a virtual machine image might be required. Some virtual machine images have licensed versions of software installed and the cost is included in the per-minute rate for the server. Examples are the virtual machine images for SQL Server 2014 and SQL Server 2016. 
   
-Some virtual machine images have trial versions of applications installed and need additional software application licenses for use beyond the trial period. For example, the SharePoint Server 2016 Trial virtual machine image includes a trial version of SharePoint Server 2016 pre-installed. To continue using SharePoint Server 2016 after the trail expiration date, you must purchase a SharePoint Server 2016 license and client licenses from Microsoft. These charges are separate from the Azure subscription and the per-minute rate to run the virtual machine still applies.
+Some virtual machine images have trial versions of applications installed and need additional software application licenses for use beyond the trial period. For example, the SharePoint Server 2016 Trial virtual machine image includes a trial version of SharePoint Server 2016 pre-installed. To continue using SharePoint Server 2016 after the trial expiration date, you must purchase a SharePoint Server 2016 license and client licenses from Microsoft. These charges are separate from the Azure subscription and the per-minute rate to run the virtual machine still applies.
   
 ### User accounts
 


### PR DESCRIPTION
Resolves #561

Spelling error on this sentence "To continue using SharePoint Server 2016 after the trail expiration date.." in line 71