### PR TITLE
Update prepare-for-directory-synchronization.md

### DIFF
--- a/Enterprise/prepare-for-directory-synchronization.md
+++ b/Enterprise/prepare-for-directory-synchronization.md
@@ -52,10 +52,7 @@ Before you synchronize your AD DS to your Azure AD tenant, you need to clean up 
 In your AD DS, complete the following clean-up tasks for each user account that will be assigned an Office 365 license:
   
 1. Ensure a valid and unique email address in the **proxyAddresses** attribute. 
-
-  >[!Note]
-  >A tilde (~) character in email addresses will be ignored. This can lead to false-positive directory synchronization errors about duplicate proxyAddresses.
-    
+  
 2. Remove any duplicate values in the **proxyAddresses** attribute. 
     
 3.  If possible, ensure a valid and unique value for the **userPrincipalName** attribute in the user's **user** object. For the best synchronization experience, ensure that the AD DS UPN matches the Azure AD UPN. If a user does not have a value for the **userPrincipalName** attribute, then the **user** object must contain a valid and unique value for the **sAMAccountName** attribute. Remove any duplicate values in the **userPrincipalName** attribute. 


### PR DESCRIPTION
Removing this recently added note about tilde character as this was not accurate. 
We are not "ignoring" the tilde character whatsoever. We synchronize the tilde character as expected, but on top of that, we also add the UPN address as a secondary smtp address which does not have a tilde char (UPNs cannot have special characters). So in reality, we are synchronizing the proxy address with a tilde char plus the UPN as a secondary smtp address - I believe this secondary address was giving the wrong impression that the tilde char was being skipped.
Additionally, there's another secondary SMTP that is automatically added based in the MailnickName@Tenant.onmicrosoft.com (aka, MOERA address). In this case the tilde character will be replaced by an underscore '_' because the MailnickName cannot contain special characters either, as explained in this page under MailnickName.