### PR TITLE
Update search parameters on disable-access-to-services-with-office-365-powershell.md

### DIFF
--- a/Enterprise/powershell/disable-access-to-services-with-office-365-powershell.md
+++ b/Enterprise/powershell/disable-access-to-services-with-office-365-powershell.md
@@ -99,7 +99,7 @@ To disable the services described in Step 1 for all existing licensed users, spe
     
 ```powershell
 $acctSKU="<AccountSkuId>"
-$AllLicensed = Get-MsolUser -All | Where {$_.isLicensed -eq $true -and $_.licenses[0].AccountSku.SkuPartNumber -eq ($acctSKU).Substring($acctSKU.IndexOf(":")+1, $acctSKU.Length-$acctSKU.IndexOf(":")-1)}
+$AllLicensed = Get-MsolUser -All | Where {$_.isLicensed -eq $true -and $_.licenses.AccountSku.SkuPartNumber -contains ($acctSKU).Substring($acctSKU.IndexOf(":")+1, $acctSKU.Length-$acctSKU.IndexOf(":")-1)}
 $AllLicensed | ForEach {Set-MsolUserLicense -UserPrincipalName $_.UserPrincipalName -LicenseOptions $LO}
 ```
 


### PR DESCRIPTION
If you have users with multiple licenses assigned, you need to search on the whole list of licenses instead the first entry only.