### PR TITLE
Fixing wrong PDL code of SWE to correct value.

### DIFF
--- a/Enterprise/includes/office-365-multi-geo-locations.md
+++ b/Enterprise/includes/office-365-multi-geo-locations.md
@@ -10,7 +10,7 @@
 |Japan                        |JPN     |Southeast or East Asia datacenters|
 |Korea                        |KOR     |Southeast or East Asia datacenters|
 |North America                |NAM     |US datacenters                    |
-|South Africa                 |ZAF     |(eDiscovery DCs coming soon)      |
-|Switzerland                  |CHE     |(eDiscovery DCs coming soon)      |
-|United Arab Emirates         |ARE     |(eDiscovery DCs coming soon)      |
+|South Africa                 |ZAF     |(coming soon)                     |
+|Switzerland                  |CHE     |(coming soon)                     |
+|United Arab Emirates         |ARE     |(coming soon)                     |
 |United Kingdom               |GBR     |Europe datacenters                |

--- a/Enterprise/includes/office-365-multi-geo-locations.md
+++ b/Enterprise/includes/office-365-multi-geo-locations.md
@@ -12,5 +12,5 @@
 |North America                |NAM     |US datacenters                    |
 |South Africa                 |ZAF     |(eDiscovery DCs coming soon)      |
 |Switzerland                  |CHE     |(eDiscovery DCs coming soon)      |
-|United Arab Emirates         |ARE     |(eDiscovery DCs Coming soon)      |
+|United Arab Emirates         |ARE     |(eDiscovery DCs coming soon)      |
 |United Kingdom               |GBR     |Europe datacenters                |

--- a/Enterprise/includes/office-365-multi-geo-locations.md
+++ b/Enterprise/includes/office-365-multi-geo-locations.md
@@ -11,6 +11,6 @@
 |Korea                        |KOR     |Southeast or East Asia datacenters|
 |North America                |NAM     |US datacenters                    |
 |South Africa                 |ZAF     |(eDiscovery DCs coming soon)      |
-|Switzerland                  |CHE     |(eDiscovery DCs Coming soon)      |
+|Switzerland                  |CHE     |(eDiscovery DCs coming soon)      |
 |United Arab Emirates         |ARE     |(eDiscovery DCs Coming soon)      |
 |United Kingdom               |GBR     |Europe datacenters                |

--- a/Enterprise/includes/office-365-multi-geo-locations.md
+++ b/Enterprise/includes/office-365-multi-geo-locations.md
@@ -10,7 +10,7 @@
 |Japan                        |JPN     |Southeast or East Asia datacenters|
 |Korea                        |KOR     |Southeast or East Asia datacenters|
 |North America                |NAM     |US datacenters                    |
-|South Africa                 |ZAF     |(eDiscovery DCs Coming soon)      |
+|South Africa                 |ZAF     |(eDiscovery DCs coming soon)      |
 |Switzerland                  |CHE     |(eDiscovery DCs Coming soon)      |
 |United Arab Emirates         |ARE     |(eDiscovery DCs Coming soon)      |
 |United Kingdom               |GBR     |Europe datacenters                |

--- a/Enterprise/includes/office-365-multi-geo-locations.md
+++ b/Enterprise/includes/office-365-multi-geo-locations.md
@@ -10,7 +10,7 @@
 |Japan                        |JPN     |Southeast or East Asia datacenters|
 |Korea                        |KOR     |Southeast or East Asia datacenters|
 |North America                |NAM     |US datacenters                    |
-|South Africa                 |ZAF     |(Coming soon)                     |
-|Switzerland                  |SWE     |(Coming soon)                     |
-|United Arab Emirates         |ARE     |(Coming soon)                     |
+|South Africa                 |ZAF     |(eDiscovery DCs Coming soon)      |
+|Switzerland                  |CHE     |(eDiscovery DCs Coming soon)      |
+|United Arab Emirates         |ARE     |(eDiscovery DCs Coming soon)      |
 |United Kingdom               |GBR     |Europe datacenters                |

--- a/Enterprise/includes/office-365-multi-geo-locations.md
+++ b/Enterprise/includes/office-365-multi-geo-locations.md
@@ -10,7 +10,7 @@
 |Japan                        |JPN     |Southeast or East Asia datacenters|
 |Korea                        |KOR     |Southeast or East Asia datacenters|
 |North America                |NAM     |US datacenters                    |
-|South Africa                 |ZAF     |(coming soon)                     |
-|Switzerland                  |CHE     |(coming soon)                     |
-|United Arab Emirates         |ARE     |(coming soon)                     |
+|South Africa                 |ZAF     |(Coming soon)                     |
+|Switzerland                  |CHE     |(Coming soon)                     |
+|United Arab Emirates         |ARE     |(Coming soon)                     |
 |United Kingdom               |GBR     |Europe datacenters                |


### PR DESCRIPTION
Somehow the wrong PDL code of SWE made it into this list. I have fixed it to the correct ISO 3166-1 alpha-3 value of CHE. I also tweaked the 'coming soon' text in the eDiscovery data location column to be more descriptive for CHE/ARE/ZAF as it kept confusing customers into thinking the geos were not yet launched for Multi-Geo itself.