### PR TITLE
Correcting format issue for code block

### DIFF
--- a/Enterprise/powershell/connect-to-office-365-powershell.md
+++ b/Enterprise/powershell/connect-to-office-365-powershell.md
@@ -158,9 +158,8 @@ If you receive errors, check the following requirements:
     
 - **If you receive a "Get-Item : Cannot find path" error, use this command:** 
 
-  ```powershell
+```powershell
   (dir "C:\Program Files\WindowsPowerShell\Modules\MSOnline").Name
- 
 ```
 
 ## See also


### PR DESCRIPTION
Code block was preventing the `See also` section from being formatted properly, it was continuing the code block format.

![image](https://user-images.githubusercontent.com/11204251/78565620-c97e4a80-77e3-11ea-967d-e39e8991f3b9.png)
