### PR TITLE
New articles for GCC High and DOD networking

### DIFF
--- a/Enterprise/additional-network-security-requirements-for-office-365-gcchigh-and-dod.md
+++ b/Enterprise/additional-network-security-requirements-for-office-365-gcchigh-and-dod.md
@@ -1,0 +1,65 @@
+---
+title: "Additional network security requirements for Office 365 GCC High and DoD"
+ms.author: dzazzo
+author: dzazzo
+manager: dzazzo
+ms.date: 05/19/2020
+audience: ITPro
+ms.topic: conceptual
+ms.service: o365-administration
+localization_priority: Normal
+ms.collection: 
+- M365-subscription-management
+- Strat_O365_Enterprise
+ms.custom: Adm_O365
+search.appverid:
+- OGA150m
+- OGC150
+- OGD150
+- MOE150
+ms.assetid: 
+description: "Summary: Office 365 GCC High and DoD have additional network security requirements"
+hideEdit: true
+---
+
+# Additional network security requirements for Office 365 GCC High and DOD
+
+*This article applies to Office 365 GCC High, Office 365 DOD, Microsoft 365 GCC High, and Microsoft 365 DOD.*
+
+Office 365 GCC High and DOD are secure cloud environments to meet the needs of the United States Government and its suppliers and contractors.  These cloud environments have additional network restrictions on which external endpoints the services are permitted to access.
+
+GCC High and DOD customers planning to use federated identities or hybrid co-existence may require Microsoft to permit inbound and/or outbound access to your existing on-premises deployments.  Examples of these activities include:
+
+* Use of federated identities (with Active Directory Federation Services or similar supported STS)
+* Hybrid coexistence with an on-premises Exchange Server or Skype for Business deployment
+* Migration of existing user content from an on-premises system
+
+To permit the service to communicate with your on-premises endpoints, you **must** send an email to Office 365 engineering for network changes.
+
+> [!WARNING]
+> All requests have a **three-week** SLA and cannot be expedited due to the required security and compliance controls and deployment pipelines.  This includes initial onboarding network requests as well as any changes after you have migrated to the service.  Please ensure that your network teams are aware of this timeline and include it in their planning cycles.
+
+Please send an email to [Office 365 Government Network Whitelist](mailto:o365gwlt@microsoft.com) with the following information:
+
+* **To**: [Office 365 Government Network Whitelist](mailto:o365gwlt@microsoft.com)
+* **From**: A tenant administrator - the send email **must** match a Global Administrator contact in your tenant
+* **Email subject**: Office 365 GCC High Network Request - contoso.onmicrosoft.us (replace this with your tenant name)
+
+The body of your message should include the following data:
+
+* Your Microsoft Online Services tenant name (i.e. contoso.onmicrosoft.com, fabrikam.onmicrosoft.us)
+* An email distribution list that Microsoft will communicate with for on-going communications related to network changes and/or follow up for invalid subnets
+* Indicate whether you plan to use Microsoft Teams hybrid co-existence with your on-premises deployments
+* Federated identity system externally accessible URL and IP address range in CIDR notation (e.g. sts.contoso.com)
+* On-Premises PKI Certificate Revocation List URL and IP address range in CIDR notation
+* Externally accessible URL and IP address range for Exchange Server on-premises deployment in CIDR notation
+* Externally accessible URL and IP address range for Skype for Business on-premises deployment in CIDR notation
+
+For security and compliance reasons, please keep in mind the following restrictions on your request:
+
+* There is a four subnet limitation per tenant
+* Subnets must be in CIDR Notation
+* Subnet ranges cannot be larger than /24
+* We **cannot** accommodate requests to allow access to commercial cloud services (commercial Office 365, Google G-Suite, Amazon Web Services, etc.)
+
+Once your request has been received and approved by Microsoft, there is a three-week SLA for implementation and cannot be expedited.  You will receive an initial acknowledgment when we’ve received your request and a final acknowledgement once it has been completed.

--- a/Enterprise/dns-records-for-office-365-dod.md
+++ b/Enterprise/dns-records-for-office-365-dod.md
@@ -1,0 +1,70 @@
+---
+title: "DNS records for Office 365 DoD"
+ms.author: dzazzo
+author: dzazzo
+manager: dzazzo
+ms.date: 05/19/2020
+audience: ITPro
+ms.topic: conceptual
+ms.service: o365-administration
+localization_priority: Normal
+ms.collection: 
+- M365-subscription-management
+- Strat_O365_Enterprise
+ms.custom: Adm_O365
+search.appverid:
+- OGA150
+- OGC150
+- OGD150
+- MOE150
+ms.assetid: 
+description: "Summary: DNS records for Office 365 DoD"
+hideEdit: true
+---
+
+# DNS records for Office 365 DoD
+
+*This article applies to Office 365 DoD and Microsoft 365 DoD*
+
+As part of onboarding to Office 365 DoD, you will need to add your SMTP and SIP domains to your Online Services tenant.  You’ll do this using the New-MsolDomain cmdlet in Azure AD PowerShell or use the [Azure Government Portal](https://portal.azure.us) to start the process of adding the domain and proving ownership.
+
+Once you have your domains added to your tenant and validated, use the following guidance to add the appropriate DNS records for the services below.  You may need to modify the below table to fit your organization’s needs with respect to the inbound MX record(s) and any existing Exchange Autodiscover record(s) you have in place.  We strongly recommend coordinating these DNS records with your messaging team to avoid any outages or mis-delivery of email.
+
+## Exchange Online
+
+| Type | Priority | Host name | Points to address or value | TTL |
+| --- | --- | --- | --- | --- |
+| MX | 0 | @ | *tenant*.mail.protection.office365.us (see below for additional details) | 1 Hour |
+| TXT | - | @ | v=spf1 include:spf.protection.office365.us -all | 1 Hour |
+| CNAME | - | autodiscover | autodiscover-dod.office365.us | 1 Hour |
+
+### Exchange Autodiscover record
+
+If you have Exchange Server on-premises, we recommend leaving your existing record in place while you migrate to Exchange Online, and update that record once you have completed your migration.
+
+### Exchange Online MX Record
+
+The MX record value for your accepted domains follows a standard format as noted above: *tenant*.mail.protection.office365.us, replacing *tenant* with the first part of your default tenant name.
+
+For example, if your tenant name is contoso.onmicrosoft.us, you’d use **contoso.mail.protection.office365.us** as the value for your MX record.
+
+## Skype for Business Online
+
+### CNAME records
+
+| Type | Host name | Points to address or value | TTL |
+| --- | --- | --- | --- |
+| CNAME | sip | sipdir.online.dod.skypeforbusiness.us | 1 Hour |
+| CNAME | lyncdiscover | webdir.online.dod.skypeforbusiness.us | 1 Hour | 
+
+### SRV records
+
+| Type | Service | Protocol | Port | Weight | Priority | Name | Target | TTL |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SRV | \_sip | \_tls | 443 | 1 | 100 | @ | sipdir.online.dod.skypeforbusiness.us | 1 Hour |
+| SRV | \_sipfederationtls | \_tcp | 5061 | 1 | 100 | @ | sipfed.online.dod.skypeforbusiness.us | 1 Hour |
+
+## Additional DNS records
+
+> [!IMPORTANT]
+> If you have an existing *msoid* CNAME record in your DNS zone, you must **remove** the record from DNS at this time.  The msoid record is incompatible with Microsoft 365 Enterprise Apps *(formerly Office 365 ProPlus)* and will prevent activation from succeeding.

--- a/Enterprise/dns-records-for-office-365-gcc-high.md
+++ b/Enterprise/dns-records-for-office-365-gcc-high.md
@@ -1,0 +1,70 @@
+---
+title: "DNS records for Office 365 GCC High"
+ms.author: dzazzo
+author: dzazzo
+manager: dzazzo
+ms.date: 05/19/2020
+audience: ITPro
+ms.topic: conceptual
+ms.service: o365-administration
+localization_priority: Normal
+ms.collection: 
+- M365-subscription-management
+- Strat_O365_Enterprise
+ms.custom: Adm_O365
+search.appverid:
+- OGA150
+- OGC150
+- OGD150
+- MOE150
+ms.assetid: 
+description: "Summary: DNS records for Office 365 GCC High"
+hideEdit: true
+---
+
+# DNS records for Office 365 GCC High
+
+*This article applies to Office 365 GCC High and Microsoft 365 GCC High*
+
+As part of onboarding to Office 365 GCC High, you will need to add your SMTP and SIP domains to your Online Services tenant.  You’ll do this using the New-MsolDomain cmdlet in Azure AD PowerShell or use the [Azure Government Portal](https://portal.azure.us) to start the process of adding the domain and proving ownership.
+
+Once you have your domains added to your tenant and validated, use the following guidance to add the appropriate DNS records for the services below.  You may need to modify the below table to fit your organization’s needs with respect to the inbound MX record(s) and any existing Exchange Autodiscover record(s) you have in place.  We strongly recommend coordinating these DNS records with your messaging team to avoid any outages or mis-delivery of email.
+
+## Exchange Online
+
+| Type | Priority | Host name | Points to address or value | TTL |
+| --- | --- | --- | --- | --- |
+| MX | 0 | @ | *tenant*.mail.protection.office365.us (see below for additional details) | 1 Hour |
+| TXT | - | @ | v=spf1 include:spf.protection.office365.us -all | 1 Hour |
+| CNAME | - | autodiscover | autodiscover.office365.us | 1 Hour |
+
+### Exchange Autodiscover record
+
+If you have Exchange Server on-premises, we recommend leaving your existing record in place while you migrate to Exchange Online, and update that record once you have completed your migration. 
+
+### Exchange Online MX Record
+
+The MX record value for your accepted domains follows a standard format as noted above: *tenant*.mail.protection.office365.us, replacing *tenant* with the first part of your default tenant name.
+
+For example, if your tenant name is contoso.onmicrosoft.us, you’d use **contoso.mail.protection.office365.us** as the value for your MX record.
+
+## Skype for Business Online
+
+### CNAME records
+
+| Type | Host name | Points to address or value | TTL |
+| --- | --- | --- | --- |
+| CNAME | sip | sipdir.online.gov.skypeforbusiness.us | 1 Hour |
+| CNAME | lyncdiscover | webdir.online.gov.skypeforbusiness.us | 1 Hour |
+
+### SRV records
+
+| Type | Service | Protocol | Port | Weight | Priority | Name | Target | TTL |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SRV | \_sip | \_tls | 443 | 1 | 100 | @ | sipdir.online.gov.skypeforbusiness.us | 1 Hour |
+| SRV | \_sipfederationtls | \_tcp | 5061 | 1 | 100 | @ | sipfed.online.gov.skypeforbusiness.us | 1 Hour |
+
+## Additional DNS records
+
+> [!IMPORTANT]
+> If you have an existing *msoid* CNAME record in your DNS zone, you must **remove** the record from DNS at this time.  The msoid record is incompatible with Microsoft 365 Enterprise Apps *(formerly Office 365 ProPlus)* and will prevent activation from succeeding.


### PR DESCRIPTION
Moving GCC High and DOD networking articles to docs.microsoft.com and deprecating legacy PDF delivery.